### PR TITLE
Adding gulp task to build one index.css for apps which just want to h…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ node_modules
 # ignore package-lock , lock files
 package-lock.json
 *.lock
+
+# dist folder
+dist/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,7 @@ const gulp = require('gulp');
 const sass = require('gulp-sass');
 const gulpStylelint = require('gulp-stylelint');
 const runSequence = require('run-sequence');
+const del = require('del');
 const conventionalChangelog = require('gulp-conventional-changelog');
 const conventionalGitHubReleaser = require('conventional-github-releaser');
 const bump = require('gulp-bump');
@@ -102,3 +103,15 @@ gulp.task('sass', () =>
 );
 
 gulp.task('default', () => gulp.parallel('sass', 'lint-sass'));
+
+gulp.task('build:sass', () => 
+  gulp.src('./index.scss')
+  .pipe(sass({outputStyle: 'compressed'}).on('error', sass.logError))
+  .pipe(gulp.dest('./dist'))
+);
+
+gulp.task('clean:dist', () => 
+  del(['dist/**'])
+);
+
+gulp.task('build:dist', gulp.series('clean:dist', 'build:sass'));

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "conventional-github-releaser": "^1.1.12",
+    "del": "^3.0.0",
     "gulp": "github:gulpjs/gulp#4.0",
     "gulp-bump": "^2.7.0",
     "gulp-conventional-changelog": "^1.1.4",
@@ -51,10 +52,16 @@
     ],
     "rules": {
       "max-nesting-depth": 2,
-      "order/properties-alphabetical-order": null,      
-      "selector-no-qualifying-type":[true, {
-        "ignore": ["attribute", "class"]
-      }]
+      "order/properties-alphabetical-order": null,
+      "selector-no-qualifying-type": [
+        true,
+        {
+          "ignore": [
+            "attribute",
+            "class"
+          ]
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
For future projects, we might need just a distributable version of fabric, rather then using it as a npm dependency. This already came up as part of discovery for new supplier portal, therefore I just prepared everything in place, so once we need it, we can just put the task into our CI workflow.