### PR TITLE
GH-99 removed  a:focus color

### DIFF
--- a/atoms/typography/_anchors.scss
+++ b/atoms/typography/_anchors.scss
@@ -10,7 +10,6 @@ $anchor-disabled-color: $sail !default;
     transition: color 0.1s linear;
 
     &:active,
-    &:focus,
     &:hover {
       color: $anchor-hover-color;
     }


### PR DESCRIPTION
for #99 

the link was disappearing into the background.  this is fixed by removing the link focus color