### PR TITLE
feat(dist): release scss distributable in the repository

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -41,7 +41,8 @@ deployment:
     branch: master
     commands:
       - gulp bump-version changelog
-      - git add package.json doc CHANGELOG.md
+      - gulp build:dist
+      - git add package.json doc dist CHANGELOG.md
       - git commit -m "Bumped version to $(jq -r .version package.json) [skip ci]"
       - git tag -f -a $(jq -r .version package.json) -m "Automatic release via CircleCI"
       - git push origin $CIRCLE_BRANCH

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -114,4 +114,4 @@ gulp.task('clean:dist', () =>
   del(['dist/**'])
 );
 
-gulp.task('build:dist', gulp.series('clean:dist', 'build:sass'));
+gulp.task('build:dist', gulp.series('clean:dist', 'lint-sass', 'build:sass'));


### PR DESCRIPTION
For the Retail Portal, we need the one .css file distributable. The gulp tasks are already there, now we need to enable the release via CI