### PR TITLE
fix(header): the dropdown for lang change css classes 

### DIFF
--- a/molecules/_header.scss
+++ b/molecules/_header.scss
@@ -133,6 +133,24 @@ $header-border-color: schema-color(4) !default;
         .icon {
           vertical-align: middle;
         }
+
+        li:not(.dropdown-item) {
+          display: inline-block;
+          text-transform: uppercase;
+          transition: all 0.2s linear;
+    
+          &:hover,
+          &.is-hovered {
+            background-color: $header-accent-background-color;
+          }
+    
+          a,
+          .dropdown-trigger {
+            display: block;
+            cursor: pointer;
+            padding: 0 $space-m;
+          }
+        }
       }
     }
 
@@ -141,24 +159,6 @@ $header-border-color: schema-color(4) !default;
 
       .main-sub-menu {
         @include main-sub-menu;
-      }
-    }
-
-    li:not(.dropdown-item) {
-      display: inline-block;
-      text-transform: uppercase;
-      transition: all 0.2s linear;
-
-      &:hover,
-      &.is-hovered {
-        background-color: $header-accent-background-color;
-      }
-
-      a,
-      .dropdown-trigger {
-        display: block;
-        cursor: pointer;
-        padding: 0 $space-m;
       }
     }
 


### PR DESCRIPTION
Using a custom WSDRopdown in the header causes a weird hover effect because the global .ws-header .dropdown-trigger rules are not scoped to "menu-controls" which is why this bug results.

IS:
![dropdown-header-ssue](https://user-images.githubusercontent.com/1215719/41853137-56085e1c-788d-11e8-98dd-f9869dbb4b64.gif)

After FIX:

![fix-of-dd-header](https://user-images.githubusercontent.com/1215719/41853240-a3cde824-788d-11e8-931f-780a9ae2232d.gif)
