### PR TITLE
feature(build): Adding fonts to the output folder so they can be load…

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,8 +110,13 @@ gulp.task('build:sass', () =>
   .pipe(gulp.dest('./build'))
 );
 
+gulp.task('copy:fonts', () => {
+  return gulp.src('./fonts/*')
+  .pipe(gulp.dest('build/fonts/'))
+});
+
 gulp.task('clean:dist', () => 
   del(['build/**'])
 );
 
-gulp.task('build:dist', gulp.series('clean:dist', 'lint-sass', 'build:sass'));
+gulp.task('build:dist', gulp.series('clean:dist', 'lint-sass', 'copy:fonts','build:sass'));


### PR DESCRIPTION
If you start using the build output with Rawgit, e.g. https://cdn.rawgit.com/fabric-design/scss/master/build/index.css it starts loading fonts from "fonts/" folder.

Luckily with RawGit CDN, we just need to copy (provide) the fonts on the same level.

